### PR TITLE
fix: Reset email and password input after sign in

### DIFF
--- a/src/pages/Login/SigninForm/index.tsx
+++ b/src/pages/Login/SigninForm/index.tsx
@@ -30,6 +30,8 @@ const SigninForm: React.FC = () => {
   const onSubmit = async (data: loginObject) => {
     try {
       await authApi.signInUser(data);
+
+      reset({email: '', password: ''}, {keepErrors: false});
       
       return navigation.navigate('Home');
     } catch (error: unknown) {


### PR DESCRIPTION
Whenever user correctly write their credentials, if they "log out" (go back), the form is still filled. That shouldn't happen