### PR TITLE
Refactor: Use same naming pattern for styled components, and move types to their own file

### DIFF
--- a/src/components/GenericButton/index.tsx
+++ b/src/components/GenericButton/index.tsx
@@ -1,12 +1,5 @@
-import { ImageSourcePropType } from "react-native";
-import { ButtonIcon, ButtonStyleProps, ButtonText, StyledButton } from "./style";
-import { TouchableOpacityProps } from "react-native-gesture-handler";
-import { ReactNode } from "react";
-
-interface GenericButtonProps extends ButtonStyleProps, TouchableOpacityProps {
-  children: ReactNode;
-  icon?: ImageSourcePropType;
-}
+import { ButtonIcon, ButtonText, StyledButton } from "./style";
+import { GenericButtonProps } from "./type";
 
 /**
  * Generic button to ensure style consistency across components

--- a/src/components/GenericButton/index.tsx
+++ b/src/components/GenericButton/index.tsx
@@ -1,4 +1,4 @@
-import { ButtonIcon, ButtonText, StyledButton } from "./style";
+import { StyledButtonText, StyledButtonIcon, StyledButton } from "./style";
 import { GenericButtonProps } from "./type";
 
 /**
@@ -15,13 +15,13 @@ const GenericButton: React.FC<GenericButtonProps> = ({ icon, state, children, ..
   return (
     <StyledButton state={state} {...rest}>
       {icon && (
-        <ButtonIcon
+        <StyledButtonIcon
           importantForAccessibility="no"
           accessibilityElementsHidden={true}
           source={icon}
         />
       )}
-      <ButtonText state={state}>{children}</ButtonText>
+      <StyledButtonText state={state}>{children}</StyledButtonText>
     </StyledButton>
   );
 };

--- a/src/components/GenericButton/style.tsx
+++ b/src/components/GenericButton/style.tsx
@@ -1,9 +1,6 @@
 import styled from "styled-components/native";
 import { TextMontserrat } from "../TextBox/style";
-
-export interface ButtonStyleProps {
-  state?: "accent" | "mild" | "default";
-}
+import { ButtonStyleProps } from "./type";
 
 export const StyledButton = styled.TouchableOpacity<ButtonStyleProps>`
   display: flex;

--- a/src/components/GenericButton/style.tsx
+++ b/src/components/GenericButton/style.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components/native";
-import { TextMontserrat } from "../TextBox/style";
+import { StyledText } from "../TextBox/style";
 import { ButtonStyleProps } from "./type";
 
 export const StyledButton = styled.TouchableOpacity<ButtonStyleProps>`
@@ -24,12 +24,12 @@ export const StyledButton = styled.TouchableOpacity<ButtonStyleProps>`
   }};
 `;
 
-export const ButtonIcon = styled.Image`
+export const StyledButtonIcon = styled.Image`
   width: 30px;
   height: 30px;
 `;
 
-export const ButtonText = styled(TextMontserrat)<ButtonStyleProps>`
+export const StyledButtonText = styled(StyledText)<ButtonStyleProps>`
   color: ${({ state }) => {
     switch (state) {
       case "accent":

--- a/src/components/GenericButton/type.ts
+++ b/src/components/GenericButton/type.ts
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+import { TouchableOpacityProps } from "react-native-gesture-handler";
+import { ImageSourcePropType } from "react-native";
+
+export interface ButtonStyleProps {
+  state?: "accent" | "mild" | "default";
+}
+
+export interface GenericButtonProps extends ButtonStyleProps, TouchableOpacityProps {
+  children: ReactNode;
+  icon?: ImageSourcePropType;
+}

--- a/src/components/GenericInput/index.tsx
+++ b/src/components/GenericInput/index.tsx
@@ -4,11 +4,7 @@ import { GenericInputProps } from "./type";
 import { useController } from "react-hook-form";
 
 /**
- * Generic text input to ensure style consistency across components
- *
- * If you need to style it further, you can import just the styleSheet like so:
- * import StyledInput from "./path";
- * export const AnotherInput = styled(StyledInput)` // rest of the styles `
+ * Generic text input with label and error message to ensure style consistency across components
  */
 const GenericInput: React.FC<GenericInputProps> = ({ label, control, name, errors, ...props }) => {
   const { field } = useController({ control, defaultValue: "", name });

--- a/src/components/GenericInput/style.tsx
+++ b/src/components/GenericInput/style.tsx
@@ -1,10 +1,10 @@
 import styled from "styled-components/native";
-import { TextMontserrat } from "../TextBox/style";
+import { StyledText } from "../TextBox/style";
 import { StyledInputProps } from "./type";
 
 export const StyledContainer = styled.View``;
 
-export const StyledLabel = styled(TextMontserrat)`
+export const StyledLabel = styled(StyledText)`
   margin-bottom: 12px;
 `;
 
@@ -16,7 +16,7 @@ export const StyledInput = styled.TextInput<StyledInputProps>`
   border: ${(props) => (props.errors && props.errors[props.name] ? "#FF0000" : "none")};
 `;
 
-export const StyledInputError = styled(TextMontserrat)`
+export const StyledInputError = styled(StyledText)`
   color: #ff0000;
   font-size: 14px;
 `;

--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { LogoBox, LogoImg } from "./style";
+import { StyledLogoContainer, StyledLogo } from "./style";
 
 const Logo: React.FC = () => {
   return (
-    <LogoBox>
-      <LogoImg source={require("../../../assets/logo.png")} resizeMode="cover"></LogoImg>
-    </LogoBox>
+    <StyledLogoContainer>
+      <StyledLogo source={require("../../../assets/logo.png")} resizeMode="cover"></StyledLogo>
+    </StyledLogoContainer>
   );
 };
 

--- a/src/components/Logo/style.tsx
+++ b/src/components/Logo/style.tsx
@@ -1,12 +1,12 @@
 import styled from "styled-components/native";
 
-export const LogoImg = styled.ImageBackground`
+export const StyledLogo = styled.ImageBackground`
   display: flex;
   width: 147px;
   height: 139px;
 `;
 
-export const LogoBox = styled.View`
+export const StyledLogoContainer = styled.View`
   display: flex;
   align-items: center;
 `;

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -1,9 +1,5 @@
-import { ReactNode } from "react";
 import { TextMontserrat } from "./style";
-
-interface TextBoxProps {
-  children: ReactNode;
-}
+import { TextBoxProps } from "./type";
 
 /**
  * This ensures font family can be consistent across all components

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -1,4 +1,4 @@
-import { TextMontserrat } from "./style";
+import { StyledText } from "./style";
 import { TextBoxProps } from "./type";
 
 /**
@@ -11,7 +11,7 @@ import { TextBoxProps } from "./type";
  * export const CustomText = styled(TextMontserrat)` -- rest of the code `
  */
 const TextBox: React.FC<TextBoxProps> = ({ children }) => {
-  return <TextMontserrat>{children}</TextMontserrat>;
+  return <StyledText>{children}</StyledText>;
 };
 
 export default TextBox;

--- a/src/components/TextBox/style.tsx
+++ b/src/components/TextBox/style.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components/native";
 
-export const TextMontserrat = styled.Text`
+export const StyledText = styled.Text`
   font-family: "Montserrat";
 `;

--- a/src/components/TextBox/type.ts
+++ b/src/components/TextBox/type.ts
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export interface TextBoxProps {
+  children: ReactNode;
+}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,21 +1,13 @@
 import React from "react";
-import { Text, StyleSheet, View } from "react-native";
+import { StyledHomeContainer } from "./style";
+import TextBox from "../../components/TextBox";
 
 const Home: React.FC = () => {
   return (
-    <View style={styles.container}>
-      <Text>Tela de ínicio</Text>
-    </View>
+    <StyledHomeContainer>
+      <TextBox>Tela de ínicio</TextBox>
+    </StyledHomeContainer>
   );
 };
 
 export default Home;
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#FAFCFF",
-    justifyContent: "center",
-    alignItems: "center"
-  }
-});

--- a/src/pages/Home/style.tsx
+++ b/src/pages/Home/style.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components/native";
+
+export const StyledHomeContainer = styled.View`
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: #fafcff;
+`;

--- a/src/pages/Login/SigninForm/index.tsx
+++ b/src/pages/Login/SigninForm/index.tsx
@@ -23,10 +23,8 @@ import GenericButton from "../../../components/GenericButton";
 import GenericInput from "../../../components/GenericInput";
 import { FormInputsType } from "../type";
 
-type HomeScreenProp = StackNavigationProp<RootStackParamList, "Home">;
-
 const SigninForm: React.FC = () => {
-  const navigation = useNavigation<HomeScreenProp>();
+  const navigation = useNavigation<NavigationType>();
 
   const {
     handleSubmit,

--- a/src/pages/Login/SigninForm/index.tsx
+++ b/src/pages/Login/SigninForm/index.tsx
@@ -1,27 +1,25 @@
 import React from "react";
 import { ActivityIndicator, Alert, FlatList } from "react-native";
 import {
-  ForgotPasswordText,
-  FormBox,
-  LoginWrapper,
-  RegisterContainer,
-  RegisterLink,
-  TitleText
+  StyledForgottenPassword,
+  StyledFormContainer,
+  StyledLoginWrapper,
+  StyledRegisterWrapper,
+  StyledRegisterLink,
+  StyledTitle
 } from "./style";
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { loginSchema } from "../../../schemas/loginSchema";
 import { loginObject } from "../../../types/loginType";
 import { useNavigation } from "@react-navigation/native";
-import { StackNavigationProp } from "@react-navigation/stack";
 import axios from "axios";
 import authApi from "../../../services/authApi";
 import { TouchableOpacity } from "react-native-gesture-handler";
-import { RootStackParamList } from "../../../types/routeType";
 import TextBox from "../../../components/TextBox";
 import GenericButton from "../../../components/GenericButton";
 import GenericInput from "../../../components/GenericInput";
-import { FormInputsType } from "../type";
+import { FormInputsType, NavigationType } from "../type";
 
 const SigninForm: React.FC = () => {
   const navigation = useNavigation<NavigationType>();
@@ -79,8 +77,8 @@ const SigninForm: React.FC = () => {
   ];
 
   return (
-    <FormBox>
-      <TitleText>Vamos começar?</TitleText>
+    <StyledFormContainer>
+      <StyledTitle>Vamos começar?</StyledTitle>
 
       <FlatList<FormInputsType>
         data={formInputs}
@@ -97,23 +95,23 @@ const SigninForm: React.FC = () => {
       />
 
       <TouchableOpacity onPress={() => navigation.navigate("PasswordReset")}>
-        <ForgotPasswordText>Esqueci a senha</ForgotPasswordText>
+        <StyledForgottenPassword>Esqueci a senha</StyledForgottenPassword>
       </TouchableOpacity>
 
-      <LoginWrapper>
+      <StyledLoginWrapper>
         <GenericButton state="accent" onPress={handleSubmit(onSubmit)}>
           {isSubmitting ? <ActivityIndicator color={"#fff"} /> : "Login"}
         </GenericButton>
-      </LoginWrapper>
+      </StyledLoginWrapper>
 
-      <RegisterContainer>
+      <StyledRegisterWrapper>
         <TextBox>Não tem conta?</TextBox>
 
         <TouchableOpacity onPress={() => navigation.navigate("SignUp")}>
-          <RegisterLink> Registre-se</RegisterLink>
+          <StyledRegisterLink> Registre-se</StyledRegisterLink>
         </TouchableOpacity>
-      </RegisterContainer>
-    </FormBox>
+      </StyledRegisterWrapper>
+    </StyledFormContainer>
   );
 };
 

--- a/src/pages/Login/SigninForm/index.tsx
+++ b/src/pages/Login/SigninForm/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ActivityIndicator, Alert, FlatList, KeyboardTypeOptions } from "react-native";
+import { ActivityIndicator, Alert, FlatList } from "react-native";
 import {
   ForgotPasswordText,
   FormBox,
@@ -21,16 +21,9 @@ import { RootStackParamList } from "../../../types/routeType";
 import TextBox from "../../../components/TextBox";
 import GenericButton from "../../../components/GenericButton";
 import GenericInput from "../../../components/GenericInput";
+import { FormInputsType } from "../type";
 
 type HomeScreenProp = StackNavigationProp<RootStackParamList, "Home">;
-
-// Will be extracted in a later refactor with the others
-interface FormInputsType {
-  label: string;
-  name: string;
-  keyboard: KeyboardTypeOptions;
-  autoComplete: "email" | "password";
-}
 
 const SigninForm: React.FC = () => {
   const navigation = useNavigation<HomeScreenProp>();

--- a/src/pages/Login/SigninForm/style.tsx
+++ b/src/pages/Login/SigninForm/style.tsx
@@ -1,43 +1,30 @@
 import styled from "styled-components/native";
-import { TextMontserrat } from "../../../components/TextBox/style";
+import { StyledText } from "../../../components/TextBox/style";
 
-export const FormBox = styled.View``;
+export const StyledFormContainer = styled.View``;
 
-export const TitleText = styled(TextMontserrat)`
+export const StyledTitle = styled(StyledText)`
   font-size: 24px;
   font-weight: 400;
   margin: 81px 0px 24px;
 `;
 
-export const FormButton = styled.TouchableOpacity`
-  display: flex;
-  align-items: center;
-  background-color: #8e37c9;
-  border-radius: 10px;
-  padding: 16px;
-  margin: 34px 0px 24px;
-`;
-
-export const FormButtonText = styled(TextMontserrat)`
-  color: white;
-`;
-
-export const ForgotPasswordText = styled(TextMontserrat)`
+export const StyledForgottenPassword = styled(StyledText)`
   color: #af65e2;
   text-align: right;
   margin: 0px 12px;
 `;
 
-export const LoginWrapper = styled.View`
+export const StyledLoginWrapper = styled.View`
   margin: 34px 0px 24px;
 `;
 
-export const RegisterContainer = styled.View`
+export const StyledRegisterWrapper = styled.View`
   display: flex;
   flex-direction: row;
   justify-content: center;
 `;
 
-export const RegisterLink = styled(TextMontserrat)`
+export const StyledRegisterLink = styled(StyledText)`
   color: #af65e2;
 `;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
 import SigninForm from "./SigninForm";
-import { LoginBox } from "./style";
 import Logo from "../../components/Logo";
+import { StyledLoginContainer } from "./style";
 
 const Login: React.FC = () => {
   return (
     <View style={styles.container}>
-      <LoginBox>
+      <StyledLoginContainer>
         <Logo />
         <SigninForm />
-      </LoginBox>
+      </StyledLoginContainer>
     </View>
   );
 };

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -6,24 +6,11 @@ import { StyledLoginContainer } from "./style";
 
 const Login: React.FC = () => {
   return (
-    <View style={styles.container}>
-      <StyledLoginContainer>
-        <Logo />
-        <SigninForm />
-      </StyledLoginContainer>
-    </View>
+    <StyledLoginContainer>
+      <Logo />
+      <SigninForm />
+    </StyledLoginContainer>
   );
 };
 
 export default Login;
-
-// Just a placeholder so I could remove it from the App.tsx
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#FAFCFF",
-    justifyContent: "center",
-    padding: 30
-  }
-});

--- a/src/pages/Login/style.tsx
+++ b/src/pages/Login/style.tsx
@@ -4,4 +4,6 @@ export const StyledLoginContainer = styled.View`
   display: flex;
   justify-content: center;
   height: 100%;
+  padding: 30px;
+  background-color: #FAFCFF;
 `;

--- a/src/pages/Login/style.tsx
+++ b/src/pages/Login/style.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components/native";
 
-export const LoginBox = styled.View`
+export const StyledLoginContainer = styled.View`
   display: flex;
   justify-content: center;
   height: 100%;

--- a/src/pages/Login/type.ts
+++ b/src/pages/Login/type.ts
@@ -1,0 +1,8 @@
+import { KeyboardTypeOptions } from "react-native";
+
+export interface FormInputsType {
+  label: string;
+  name: string;
+  keyboard: KeyboardTypeOptions;
+  autoComplete: "email" | "password";
+}

--- a/src/pages/Login/type.ts
+++ b/src/pages/Login/type.ts
@@ -1,4 +1,6 @@
 import { KeyboardTypeOptions } from "react-native";
+import { RootStackParamList } from "../../types/routeType";
+import { StackNavigationProp } from "@react-navigation/stack";
 
 export interface FormInputsType {
   label: string;
@@ -6,3 +8,7 @@ export interface FormInputsType {
   keyboard: KeyboardTypeOptions;
   autoComplete: "email" | "password";
 }
+
+// TODO: Gotta check if this is something I can re-use in other components outside login, 
+// hence needing to move it to root types folder
+export type NavigationType = StackNavigationProp<RootStackParamList>;

--- a/src/pages/PasswordReset/index.tsx
+++ b/src/pages/PasswordReset/index.tsx
@@ -1,11 +1,11 @@
-import { Text } from "react-native";
-import { Container } from "./style";
+import { StyledPasswordResetContainer } from "./style";
+import TextBox from "../../components/TextBox";
 
 const PasswordReset: React.FC = () => {
   return (
-    <Container>
-      <Text>Tela de recuperação de senha</Text>
-    </Container>
+    <StyledPasswordResetContainer>
+      <TextBox>Tela de recuperação de senha</TextBox>
+    </StyledPasswordResetContainer>
   );
 };
 

--- a/src/pages/PasswordReset/style.tsx
+++ b/src/pages/PasswordReset/style.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components/native";
 
-// Name subject to change. Just a placeholder for now
-export const Container = styled.View`
+export const StyledPasswordResetContainer = styled.View`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,11 +1,11 @@
-import { Text } from "react-native";
-import { Container } from "./style";
+import { StyledSignUpContainer } from "./style";
+import TextBox from "../../components/TextBox";
 
 const SignUp: React.FC = () => {
   return (
-    <Container>
-      <Text>Tela de cadastro</Text>
-    </Container>
+    <StyledSignUpContainer>
+      <TextBox>Tela de cadastro</TextBox>
+    </StyledSignUpContainer>
   );
 };
 

--- a/src/pages/SignUp/style.tsx
+++ b/src/pages/SignUp/style.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components/native";
 
-// Name subject to change. Just a placeholder for now
-export const Container = styled.View`
+export const StyledSignUpContainer = styled.View`
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
As it was getting harder to distinguish between a normal component and a styledComponent, it's been proposed that we name all styled components following: Styled[NameOfTheComponent]

We also decided to move the typings to its own file so it is easier to re-use them across JSX and Styling