### PR TITLE
cia-343-reorder-app-journey

### DIFF
--- a/src/components/GenericButton/ButtonChildren/style.ts
+++ b/src/components/GenericButton/ButtonChildren/style.ts
@@ -14,6 +14,7 @@ export const Sc = {
     color: ${({ state }) =>
       state === "accent" ? Palette.neutralWhite[50] : NewColorScheme.accent.highlight};
     font-family: ${FontScheme.family.primary};
+    line-height: 24px;
     font-weight: 700;
     font-size: ${FontScheme.size.medium}px;
     opacity: ${({ disabled }) => (disabled ? 0.4 : 1)};

--- a/src/components/GenericButton/style.ts
+++ b/src/components/GenericButton/style.ts
@@ -13,7 +13,7 @@ export const Sc = {
     border-radius: 10px;
     padding: ${({ padding }) => padding ?? "14px"};
     border: ${({ state }) =>
-      !state || state === "default" ? `2px solid ${ColorScheme.border.primary}` : "none"};
+      !state || state === "default" ? `2px solid ${NewColorScheme.accent.highlight}` : "none"};
     background-color: ${({ state }) => {
       switch (state) {
         case "accent":
@@ -21,6 +21,7 @@ export const Sc = {
         case "mild":
           return ColorScheme.background.secondary;
         case "no-style":
+          return NewColorScheme.background.white;
         case "default":
         default:
           return ColorScheme.background.primary;

--- a/src/pages/AnualCalendar/CalendarBody/index.tsx
+++ b/src/pages/AnualCalendar/CalendarBody/index.tsx
@@ -335,7 +335,7 @@ function CalendarListScreen(props: Props) {
         >
           <View style={styles.overlay}>
             <View style={styles.modalView}>
-              <Text style={styles.modalTextAlert}>Atenção! Alguns dias ficaram faltando</Text>
+              <Text style={styles.modalTextAlert}>! Alguns dias ficaram faltando</Text>
               <Text style={styles.modalText}>Você gostaria de anotar os dias anteriores?</Text>
 
               <View style={styles.buttonContainer}>

--- a/src/pages/AnualCalendar/CalendarBody/index.tsx
+++ b/src/pages/AnualCalendar/CalendarBody/index.tsx
@@ -335,7 +335,7 @@ function CalendarListScreen(props: Props) {
         >
           <View style={styles.overlay}>
             <View style={styles.modalView}>
-              <Text style={styles.modalTextAlert}>! Alguns dias ficaram faltando</Text>
+              <Text style={styles.modalTextAlert}>Atenção! Alguns dias ficaram faltando</Text>
               <Text style={styles.modalText}>Você gostaria de anotar os dias anteriores?</Text>
 
               <View style={styles.buttonContainer}>

--- a/src/pages/OnboardingCarousel/style.ts
+++ b/src/pages/OnboardingCarousel/style.ts
@@ -13,7 +13,7 @@ export const Sc = {
     flex: 1;
     flex-direction: row;
     justify-content: center;
-    /* margin-bottom: 20px; */
+    margin-bottom: 20px;
     width: 100%;
   `,
   paginationDot: styled.View<{ active?: boolean }>`


### PR DESCRIPTION
# Title

Adjustment of user onboarding flow on first app access

## Related Issues

- Ticket from Jira [`CIA-343`](https://pipocatimebordo.atlassian.net/jira/software/projects/CIA/boards/2?selectedIssue=CIA-343)

## Description

This PR makes a full adjustment to the navigation flow for the user’s first time using the app. The flow should follow this screen sequence:

- Show the splash screen when opening the app.  
- Automatically redirect to the login screen.  
- Include a **"Sign Up"** option that leads to the registration form screen.  
- From the registration screen, the user can open the **Terms of Use and Privacy Policy** via a link.  
- Allow the user to go back from the terms screen to the registration form.  
- Validate the form and redirect to the onboarding carousel after a successful registration.  

### Onboarding carousel:

- Contains 3 informational slides.  
- **"Skip"** button on the first two slides that goes directly to the **LastPeriod** screen.  
- **"Next"** button on the first two slides to go to the next slide.  
- On the third slide, only the **"Finish"** button is available, which redirects to the **LastPeriod** screen.  

### After onboarding:

- From the **LastPeriod** screen, the user is redirected to the **CycleDuration** screen.  
- After setting the cycle duration, the user is taken to the **Home** screen.  
- From the navigation menu, it is possible to access:  
  - Yearly calendar  
  - Reports page  
  - Return to **Home** screen  

## Test Plan

- Check if the splash screen shows when opening the app.  
- Confirm automatic redirection to the login screen.  
- Test the full registration flow:  
  - Open the registration screen using the **"Sign Up"** link  
  - Navigate to the terms screen and back to the form  
  - Validate the form and go to the onboarding carousel  
- Test the behavior of the **"Skip"**, **"Next"**, and **"Finish"** buttons in the carousel.  
- Make sure the flow after onboarding is:  
  - **LastPeriod → CycleDuration → Home**  
- Use the navigation menu to access and confirm the other pages (**Yearly calendar**, **Reports**, **Home**).
